### PR TITLE
add optional object_id to light entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ light:
     + **name** _(string) (Required)_: The name of the device
     + **running_time** _(int) (Optional)_: The running time in seconds for the device. If omitted, the default running time for all devices is used.
     + **dimmable** _(boolean) (Optional)_: Is the device dimmable? Default is True. 
+    + **object_id** _(string) (Optional)_: Device object_id. Default is auto-generated from device name. 
 
 #### Switch platform
 
@@ -52,6 +53,7 @@ switch:
 + **devices** _(Required)_: A list of devices to set up
   + **X.X.X** _(Required)_: The address of the device on the format `<subnet ID>.<device ID>.<channel number>`
     + **name** _(string) (Required)_: The name of the device
+    + **object_id** _(string) (Optional)_: Device object_id. Default is auto-generated from device name. 
 
 #### Sensor platform
 
@@ -80,6 +82,7 @@ sensor:
      + temperature
      + illuminance
   + **unit_of_measurement** _(string) (Optional)_: text to be displayed as unit of measurement
+  + **object_id** _(string) (Optional)_: Device object_id. Default is auto-generated from device name. 
   + **device_class** _(string) (Optional)_: HASS device class e.g., "temperature" 
   (https://www.home-assistant.io/components/sensor/)
   + **device** _(string) (Optional)_: The type of sensor device:
@@ -108,6 +111,7 @@ binary_sensor:
   + **address** _(string) (Required)_: The address of the sensor device on the format `<subnet ID>.<device ID>`. If 
   'type' = 'universal_switch' universal switch number must be appended to the address. 
   + **name** _(string) (Required)_: The name of the device
+  + **object_id** _(string) (Optional)_: Device object_id. Default is auto-generated from device name. 
   + **type** _(string) (Required)_: Type of sensor to monitor. 
     + Available sensors: 
       + motion 
@@ -139,6 +143,7 @@ climate:
 + **devices** _(Required)_: A list of devices to set up
   + **address** _(string) (Required)_: The address of the sensor device on the format `<subnet ID>.<device ID>`
   + **name** _(string) (Required)_: The name of the device
+  + **object_id** _(string) (Optional)_: Device object_id. Default is auto-generated from device name. 
   + **preset_modes** _(list) (Optional)_: List of supported preset modes. Preset mode selection is disabled if not set. Possible values are shown in table below. Corresponding modes must be enabled in HDL (Floor Heating > Working Settings > Mode).
     
 | HA preset mode | HDL mode |

--- a/custom_components/buspro/binary_sensor.py
+++ b/custom_components/buspro/binary_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.entity import generate_entity_id
 
 from datetime import timedelta
 from ..buspro import DATA_BUSPRO

--- a/custom_components/buspro/light.py
+++ b/custom_components/buspro/light.py
@@ -28,10 +28,12 @@ DEFAULT_PLATFORM_RUNNING_TIME = 0
 DEFAULT_DIMMABLE = True
 DEFAULT_OBJECT_ID = ""
 
+CONF_OBJECT_ID = "object_id"
+
 DEVICE_SCHEMA = vol.Schema({
     vol.Optional("running_time", default=DEFAULT_DEVICE_RUNNING_TIME): cv.positive_int,
     vol.Optional("dimmable", default=DEFAULT_DIMMABLE): cv.boolean,
-    vol.Optional("object_id", default=DEFAULT_OBJECT_ID): cv.string,
+    vol.Optional(CONF_OBJECT_ID, default=DEFAULT_OBJECT_ID): cv.string,
     vol.Required(CONF_NAME): cv.string,
 })
 
@@ -68,7 +70,7 @@ async def async_setup_platform(hass, config, async_add_entites, discovery_info=N
 
         light = Light(hdl, device_address, channel_number, name)
 
-        object_id = device_config["object_id"]
+        object_id = device_config[CONF_OBJECT_ID]
         if object_id == DEFAULT_OBJECT_ID:
             object_id = name
 

--- a/custom_components/buspro/pybuspro/devices/sensor.py
+++ b/custom_components/buspro/pybuspro/devices/sensor.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 # from ..helpers.generics import Generics
 from .control import _ReadSensorStatus, _ReadStatusOfUniversalSwitch, _ReadStatusOfChannels, _ReadFloorHeatingStatus, \
@@ -6,6 +7,7 @@ from .control import _ReadSensorStatus, _ReadStatusOfUniversalSwitch, _ReadStatu
 from .device import Device
 from ..helpers.enums import *
 
+_LOGGER = logging.getLogger(__name__)
 
 class Sensor(Device):
     def __init__(self, buspro, device_address, universal_switch_number=None, channel_number=None, device=None,
@@ -109,6 +111,9 @@ class Sensor(Device):
                 self._call_device_updated()
 
         elif telegram.operate_code == OperateCode.ReadStatusOfChannelsResponse:
+            if self._channel_number is None:
+                _LOGGER.warning("Sensor channel number is not set, ignoring telegram")
+                return
             if self._channel_number <= telegram.payload[0]:
                 self._channel_status = telegram.payload[self._channel_number]
                 self._call_device_updated()


### PR DESCRIPTION
This changes will provide to set object_id from yaml file instead of auto generation from name

Example of usage:
```yaml
platform: buspro
devices:
    2.9.4:
      object_id: "shadow_profile_led_bathroom"
      name: "Ванная теневой"
```
And how it will look in HA UI
![Screenshot_38](https://github.com/user-attachments/assets/88bc1af1-d600-4281-a28a-555a8b78f1ea)
